### PR TITLE
Run `kap init` after ensuring CLI is installed

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,14 @@ module.exports = {
         '@typescript-eslint/no-unsafe-assignment': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/no-misused-promises': [
+            'error',
+            {
+                checksVoidReturn: {
+                    arguments: false,
+                },
+            },
+        ],
     },
     parserOptions: {
         project: `${__dirname}/tsconfig.json`,

--- a/index.ts
+++ b/index.ts
@@ -213,7 +213,7 @@ export default {
 
                     const defaultCommands = ['codegen', 'registry'];
                     try {
-                        const ensureCLICommandsTask = await ensureCLICommands(defaultCommands);
+                        const ensureCLICommandsTask = ensureCLICommands(defaultCommands);
                         if (ensureCLICommandsTask) {
                             await taskManager.waitFor((t) => t === ensureCLICommandsTask);
                         }
@@ -231,7 +231,13 @@ export default {
                     resolve({ host, port, dockerStatus: containerManager.isAlive() });
                 }
 
-                asyncListeningListener().catch((err) => console.error('Failed to run asyncListenListener', err));
+                void (async () => {
+                    try {
+                        await asyncListeningListener();
+                    } catch (error) {
+                        console.error('Failed to run asyncListenListener', error);
+                    }
+                })();
             });
             currentServer.host = host;
             currentServer.port = port;

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import APIRoutes from './src/api';
 import { getBindHost } from './src/utils/utils';
 import request from 'request';
 import { repositoryManager } from './src/repositoryManager';
+import { taskManager } from './src/taskManager';
 import { ensureCLI, ensureCLICommands } from './src/utils/commandLineUtils';
 import { defaultProviderInstaller } from './src/utils/DefaultProviderInstaller';
 import { authManager } from './src/authManager';
@@ -201,7 +202,10 @@ export default {
 
             currentServer.listen(port, bindHost, async () => {
                 try {
-                    await ensureCLI();
+                    const ensureCLITask = await ensureCLI();
+                    if (ensureCLITask) {
+                        await taskManager.waitFor((t) => t === ensureCLITask);
+                    }
                 } catch (e: any) {
                     console.error('Failed to install CLI.', e);
                 }

--- a/index.ts
+++ b/index.ts
@@ -211,14 +211,10 @@ export default {
                         console.error('Failed to install CLI.', e);
                     }
 
-                    const defaultCommands = ['codegen', 'registry'];
                     try {
-                        const ensureCLICommandsTask = ensureCLICommands(defaultCommands);
-                        if (ensureCLICommandsTask) {
-                            await taskManager.waitFor((t) => t === ensureCLICommandsTask);
-                        }
+                        await ensureCLICommands();
                     } catch (error) {
-                        console.error(`Failed to ensure default CLI commands: %s`, defaultCommands, error);
+                        console.error('Failed to ensure default CLI commands', error);
                     }
 
                     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "@kapeta/local-cluster-service",
             "version": "0.24.3",
-            "license": "MIT",
+            "license": "BUSL-1.1",
             "dependencies": {
                 "@kapeta/codegen": "<2",
                 "@kapeta/local-cluster-config": ">= 0.2.3 <2",

--- a/src/utils/commandLineUtils.ts
+++ b/src/utils/commandLineUtils.ts
@@ -29,3 +29,28 @@ export async function ensureCLI() {
         }
     );
 }
+
+export async function hasCLICommand(command: string) {
+    return hasApp(`kap ${command}`);
+}
+
+export async function ensureCLICommands(commands: string | string[]) {
+    const commandsArray = Array.isArray(commands) ? commands : [commands];
+
+    const checkCommands = await Promise.all(commandsArray.map(hasCLICommand));
+
+    if (checkCommands.includes(false)) {
+        return taskManager.add(
+            'kap:init',
+            () => {
+                const process = spawn('kap', ['init'], { shell: true });
+                return process.wait();
+            },
+            {
+                name: 'Running `kap init` to install default CLI commands',
+            }
+        );
+    } else {
+        return null;
+    }
+}

--- a/src/utils/commandLineUtils.ts
+++ b/src/utils/commandLineUtils.ts
@@ -30,15 +30,8 @@ export async function ensureCLI() {
     );
 }
 
-export function ensureCLICommands(commands: string | string[]) {
-    return taskManager.add(
-        'kap:init',
-        () => {
-            const process = spawn('kap', ['init'], { shell: true });
-            return process.wait();
-        },
-        {
-            name: 'Installing default Kapeta CLI commands',
-        }
-    );
+export function ensureCLICommands() {
+    console.log('Run `kap init` to ensure default commands are installed');
+    const process = spawn('kap', ['init'], { shell: true });
+    return process.wait();
 }

--- a/src/utils/commandLineUtils.ts
+++ b/src/utils/commandLineUtils.ts
@@ -30,27 +30,15 @@ export async function ensureCLI() {
     );
 }
 
-export async function hasCLICommand(command: string) {
-    return hasApp(`kap ${command}`);
-}
-
-export async function ensureCLICommands(commands: string | string[]) {
-    const commandsArray = Array.isArray(commands) ? commands : [commands];
-
-    const checkCommands = await Promise.all(commandsArray.map(hasCLICommand));
-
-    if (checkCommands.includes(false)) {
-        return taskManager.add(
-            'kap:init',
-            () => {
-                const process = spawn('kap', ['init'], { shell: true });
-                return process.wait();
-            },
-            {
-                name: 'Running `kap init` to install default CLI commands',
-            }
-        );
-    } else {
-        return null;
-    }
+export function ensureCLICommands(commands: string | string[]) {
+    return taskManager.add(
+        'kap:init',
+        () => {
+            const process = spawn('kap', ['init'], { shell: true });
+            return process.wait();
+        },
+        {
+            name: 'Installing default Kapeta CLI commands',
+        }
+    );
 }


### PR DESCRIPTION
I first made a version where I attempted to verify if the default commands were installed but later realised that since `kap init` is fast to run (less than 400ms on my machine) there is no reason for first checking if the commands are missing.