### PR TITLE
fix: return all imported asset types from import endpoint [KAP-2187]

### DIFF
--- a/src/assetManager.ts
+++ b/src/assetManager.ts
@@ -244,7 +244,8 @@ class AssetManager {
 
         definitionsManager.clearCache();
 
-        const assets = await this.getAssets();
+        // Get all possible asset kinds, to make sure we return the result if possible
+        const assets = await this.getAssets([]);
 
         return assets.filter((a) => refs.some((ref) => compareRefs(ref, a.ref)));
     }


### PR DESCRIPTION
This allows us to update other assets based on the result of an import operation, regardless of the type.