### PR TITLE
fix: Be consistent when mapping web + rest to http

### DIFF
--- a/src/proxy/types/web.ts
+++ b/src/proxy/types/web.ts
@@ -27,7 +27,7 @@ export function proxyHttpRequest(req: StringBodyRequest, res: Response, opts: Pr
         path = path.replace(sourceBasePath, targetBasePath);
     }
 
-    console.log('Proxy request to provider: %s => %s%s [web]', opts.consumerPath, opts.address, path);
+    console.log('Proxy request to provider: %s => %s%s [http]', opts.consumerPath, opts.address, path);
 
     const reqOpts: SimpleRequest = {
         method: req.method,

--- a/src/serviceManager.ts
+++ b/src/serviceManager.ts
@@ -8,10 +8,13 @@ import { clusterService } from './clusterService';
 import { storageService } from './storageService';
 import { EnvironmentType } from './types';
 import { normalizeKapetaUri } from '@kapeta/nodejs-utils';
+import { resolvePortType } from './utils/BlockInstanceRunner';
 
-export const DEFAULT_PORT_TYPE = 'http';
+export const HTTP_PORT_TYPE = 'http';
 
-export const HTTP_PORTS = ['web', 'http', 'rest'];
+export const DEFAULT_PORT_TYPE = HTTP_PORT_TYPE;
+
+export const HTTP_PORTS = [HTTP_PORT_TYPE, 'web', 'rest'];
 
 class ServiceManager {
     private _systems: any;
@@ -75,9 +78,7 @@ class ServiceManager {
             portType = DEFAULT_PORT_TYPE;
         }
 
-        if (HTTP_PORTS.includes(portType)) {
-            portType = 'http';
-        }
+        portType = resolvePortType(portType);
 
         const service = this._ensureService(systemId, blockInstanceId);
 


### PR DESCRIPTION
Needs to be resolved before allocation so we dont end up mapping multiple external ports to the same internal port:

E.g. 40000 > 80 and 40001 > 80