### PR TITLE
fix: add options.fullName to local resource info

### DIFF
--- a/src/operatorManager.ts
+++ b/src/operatorManager.ts
@@ -152,6 +152,8 @@ class OperatorManager {
             type: portType,
             protocol: portInfo.protocol,
             options: {
+                // expose as fullName since that is not operator specific, but unique
+                fullName: dbName,
                 dbName,
             },
             credentials,


### PR DESCRIPTION
Seems funny to rely on `dbName` in non-db resources. `fullName` seems more universal.